### PR TITLE
Msvc fixes

### DIFF
--- a/include/delegate/delegate.hpp
+++ b/include/delegate/delegate.hpp
@@ -68,8 +68,10 @@
 
 #ifdef _MSVC_LANG
 #define CPP_VERSION _MSVC_LANG
+#define ALWAYS_INLINE __forceinline
 #else
 #define CPP_VERSION __cplusplus
+#define ALWAYS_INLINE __attribute__((always_inline))
 #endif
 
 #if CPP_VERSION < 201103L
@@ -546,7 +548,7 @@ class delegate<R(Args...)>
 
     // Call the stored function. Requires: bool(*this) == true;
     // Will call trampoline fkn which will call the final fkn.
-    constexpr R operator()(Args... args) const __attribute__((always_inline))
+    ALWAYS_INLINE constexpr R operator()(Args... args) const
     {
         return m_data.m_fkn(m_data.m_data, args...);
     }

--- a/include/delegate/delegate.hpp
+++ b/include/delegate/delegate.hpp
@@ -66,11 +66,17 @@
  * (temporary objects) for member and functor construction.
  */
 
-#if __cplusplus < 201103L
+#ifdef _MSVC_LANG
+#define CPP_VERSION _MSVC_LANG
+#else
+#define CPP_VERSION __cplusplus
+#endif
+
+#if CPP_VERSION < 201103L
 #error "Require at least C++11 to compile delegate"
 #endif
 
-#if __cplusplus >= 201402L
+#if CPP_VERSION >= 201402L
 #define DELEGATE_CXX14CONSTEXPR constexpr
 #else
 #define DELEGATE_CXX14CONSTEXPR

--- a/include/delegate/delegate.hpp
+++ b/include/delegate/delegate.hpp
@@ -323,7 +323,7 @@ class mem_fkn_base<R(Args...)>
 template <typename T, typename R, typename... Args>
 class mem_fkn<T, false, R(Args...)> : public mem_fkn_base<R(Args...)>
 {
-    using Base = class mem_fkn_base<R(Args...)>;
+    using Base = mem_fkn_base<R(Args...)>;
     static constexpr const bool cnst = false;
     using common = details::common<R(Args...)>;
     using DataPtr = typename common::DataPtr;

--- a/include/delegate/delegate.hpp
+++ b/include/delegate/delegate.hpp
@@ -67,18 +67,18 @@
  */
 
 #ifdef _MSVC_LANG
-#define CPP_VERSION _MSVC_LANG
-#define ALWAYS_INLINE __forceinline
+#define DELEGATE_CPP_VERSION _MSVC_LANG
+#define DELEGATE_ALWAYS_INLINE __forceinline
 #else
-#define CPP_VERSION __cplusplus
-#define ALWAYS_INLINE __attribute__((always_inline))
+#define DELEGATE_CPP_VERSION __cplusplus
+#define DELEGATE_ALWAYS_INLINE __attribute__((always_inline))
 #endif
 
-#if CPP_VERSION < 201103L
+#if DELEGATE_CPP_VERSION < 201103L
 #error "Require at least C++11 to compile delegate"
 #endif
 
-#if CPP_VERSION >= 201402L
+#if DELEGATE_CPP_VERSION >= 201402L
 #define DELEGATE_CXX14CONSTEXPR constexpr
 #else
 #define DELEGATE_CXX14CONSTEXPR
@@ -548,7 +548,7 @@ class delegate<R(Args...)>
 
     // Call the stored function. Requires: bool(*this) == true;
     // Will call trampoline fkn which will call the final fkn.
-    ALWAYS_INLINE constexpr R operator()(Args... args) const
+    DELEGATE_ALWAYS_INLINE constexpr R operator()(Args... args) const
     {
         return m_data.m_fkn(m_data.m_data, args...);
     }


### PR DESCRIPTION
Add MSVC support

Notably MSVC is not very good at reporting a sane __cplusplus, and doesn't support attributes in the same way as GCC/Clang.

There was also a small compile error on MSVC, that worked fine with GCC/Clang.